### PR TITLE
Add taskbar info to provide info and events when taskbar changes.

### DIFF
--- a/CSDeskBand.Win/CSDeskBandWin.cs
+++ b/CSDeskBand.Win/CSDeskBandWin.cs
@@ -7,7 +7,8 @@ namespace CSDeskBand.Win
 {
     public class CSDeskBandWin: UserControl, ICSDeskBand
     {
-        public CSDeskBandOptions Options { get; } = new CSDeskBandOptions();
+        protected CSDeskBandOptions Options { get; } = new CSDeskBandOptions();
+        protected TaskbarInfo TaskbarInfo { get; }
 
         private readonly CSDeskBandImpl _impl;
 
@@ -15,22 +16,28 @@ namespace CSDeskBand.Win
         {
             _impl = new CSDeskBandImpl(Handle, Options);
             _impl.VisibilityChanged += VisibilityChanged;
-            _impl.OnClose += OnClose;
-            _impl.TaskbarOrientationChanged += TaskbarOrientationChanged;
+            _impl.Closed += OnClose;
+            TaskbarInfo = _impl.TaskbarInfo;
         }
 
-        protected virtual void TaskbarOrientationChanged(object sender, TaskbarOrientationChangedEventArgs taskbarOrientationChangedEventArgs)
+        private void OnClose(object sender, EventArgs eventArgs)
         {
+            OnClose();
         }
 
-        protected virtual void OnClose(object sender, EventArgs eventArgs)
+        private void VisibilityChanged(object sender, VisibilityChangedEventArgs visibilityChangedEventArgs)
+        {
+            VisibilityChanged(visibilityChangedEventArgs.IsVisible);
+        }
+
+        protected virtual void OnClose()
         {
             Dispose(true);
         }
 
-        protected virtual void VisibilityChanged(object sender, VisibilityChangedEventArgs visibilityChangedEventArgs)
+        protected virtual void VisibilityChanged(bool visible)
         {
-            if (visibilityChangedEventArgs.IsVisible)
+            if (visible)
             {
                 Show();
             }

--- a/CSDeskBand.Wpf/CSDeskBandWpf.cs
+++ b/CSDeskBand.Wpf/CSDeskBandWpf.cs
@@ -9,7 +9,8 @@ namespace CSDeskBand.Wpf
 {
     public class CSDeskBandWpf : UserControl, ICSDeskBand
     {
-        public CSDeskBandOptions Options { get; } = new CSDeskBandOptions();
+        protected CSDeskBandOptions Options { get; } = new CSDeskBandOptions();
+        protected TaskbarInfo TaskbarInfo { get; }
 
         //so we can get a handle
         protected ElementHost Host { get; }
@@ -26,11 +27,17 @@ namespace CSDeskBand.Wpf
 
             _impl = new CSDeskBandImpl(Host.Handle, Options);
             _impl.VisibilityChanged += VisibilityChanged;
+            TaskbarInfo = _impl.TaskbarInfo;
         }
 
-        protected virtual void VisibilityChanged(object sender, VisibilityChangedEventArgs visibilityChangedEventArgs)
+        private void VisibilityChanged(object sender, VisibilityChangedEventArgs visibilityChangedEventArgs)
         {
-            Visibility = visibilityChangedEventArgs.IsVisible ? Visibility.Visible : Visibility.Hidden;
+            VisibilityChanged(visibilityChangedEventArgs.IsVisible);
+        }
+
+        protected virtual void VisibilityChanged(bool visible)
+        {
+            Visibility = visible ? Visibility.Visible : Visibility.Hidden;
         }
 
         public int GetWindow(out IntPtr phwnd)

--- a/CSDeskBand/CSDeskBandEvents.cs
+++ b/CSDeskBand/CSDeskBandEvents.cs
@@ -13,9 +13,13 @@ namespace CSDeskBand
         public TaskbarOrientation Orientation { get; set; }
     }
 
-    public enum TaskbarOrientation
+    public class TaskbarSizeChangedEventArgs : EventArgs
     {
-        Vertical,
-        Horizontal,
+        public Size Size { get; set; }
+    }
+
+    public class TaskbarEdgeChangedEventArgs : EventArgs
+    {
+        public Edge Edge { get; set; }
     }
 }

--- a/CSDeskBand/CSDeskband.csproj
+++ b/CSDeskBand/CSDeskband.csproj
@@ -85,6 +85,8 @@
     <Compile Include="CSDeskBandRegistrationAttribute.cs" />
     <Compile Include="CSDeskBandOptions.cs" />
     <Compile Include="ICSDeskBand.cs" />
+    <Compile Include="Interop\APPBARDATA.cs" />
+    <Compile Include="Interop\APPBARMESSAGE.cs" />
     <Compile Include="Interop\COLORREF.cs" />
     <Compile Include="Interop\COM\IDeskBand.cs" />
     <Compile Include="Interop\COM\IDeskBand2.cs" />
@@ -98,11 +100,13 @@
     <Compile Include="Interop\OLECMDTEXT.cs" />
     <Compile Include="Interop\POINT.cs" />
     <Compile Include="Interop\RECT.cs" />
+    <Compile Include="Interop\Shell32.cs" />
     <Compile Include="Interop\tagDeskBandCID.cs" />
     <Compile Include="Interop\User32.cs" />
     <Compile Include="Properties\Annotations.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Size.cs" />
+    <Compile Include="TaskbarInfo.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="Key.snk" />

--- a/CSDeskBand/Interop/APPBARDATA.cs
+++ b/CSDeskBand/Interop/APPBARDATA.cs
@@ -1,0 +1,20 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.InteropServices;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace CSDeskBand.Interop
+{
+    [StructLayout(LayoutKind.Sequential)]
+    internal struct APPBARDATA
+    {
+        public int cbSize;
+        public IntPtr hWnd;
+        public uint uCallbackMessage;
+        public uint uEdge;
+        public RECT rc;
+        public int lParam;
+    }
+}

--- a/CSDeskBand/Interop/APPBARMESSAGE.cs
+++ b/CSDeskBand/Interop/APPBARMESSAGE.cs
@@ -1,0 +1,25 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace CSDeskBand.Interop
+{
+    internal enum APPBARMESSAGE : uint
+    {
+        ABM_NEW = 0x00000000,
+        ABM_REMOVE = 0x00000001,
+        ABM_QUERYPOS = 0x00000002,
+        ABM_SETPOS = 0x00000003,
+        ABM_GETSTATE = 0x00000004,
+        ABM_GETTASKBARPOS = 0x00000005,
+        ABM_ACTIVATE = 0x00000006,
+        ABM_GETAUTOHIDEBAR = 0x00000007,
+        ABM_SETAUTOHIDEBAR = 0x00000008,
+        ABM_WINDOWPOSCHANGED = 0x00000009,
+        ABM_SETSTATE = 0x0000000A,
+        ABM_GETAUTOHIDEBAREX = 0x0000000B,
+        ABM_SETAUTOHIDEBAREX = 0x0000000C,
+    }
+}

--- a/CSDeskBand/Interop/COM/IOleCommandTarget.cs
+++ b/CSDeskBand/Interop/COM/IOleCommandTarget.cs
@@ -7,7 +7,7 @@ namespace CSDeskBand.Interop.COM
     [ComImport]
     [InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
     [Guid("b722bccb-4e68-101b-a2bc-00aa00404770")]
-    public interface IOleCommandTarget
+    internal interface IOleCommandTarget
     {
         [PreserveSig]
         void QueryStatus(ref Guid pguidCmdGroup, uint cCmds, [MarshalAs(UnmanagedType.LPArray), In, Out] OLECMD[] prgCmds, [In, Out] ref OLECMDTEXT pCmdText);

--- a/CSDeskBand/Interop/OLECMD.cs
+++ b/CSDeskBand/Interop/OLECMD.cs
@@ -3,7 +3,7 @@
 namespace CSDeskBand.Interop
 {
     [StructLayout(LayoutKind.Sequential)]
-    public struct OLECMD
+    internal struct OLECMD
     {
         public uint cmdID;
         public uint cmdf;

--- a/CSDeskBand/Interop/OLECMDTEXT.cs
+++ b/CSDeskBand/Interop/OLECMDTEXT.cs
@@ -4,7 +4,7 @@ using System.Runtime.InteropServices;
 namespace CSDeskBand.Interop
 {
     [StructLayout(LayoutKind.Sequential)]
-    public struct OLECMDTEXT
+    internal struct OLECMDTEXT
     {
         public uint cmdtextf;
         public uint cwActual;

--- a/CSDeskBand/Interop/Shell32.cs
+++ b/CSDeskBand/Interop/Shell32.cs
@@ -1,0 +1,15 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.InteropServices;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace CSDeskBand.Interop
+{
+    internal class Shell32
+    {
+        [DllImport("shell32.dll")]
+        public static extern IntPtr SHAppBarMessage(uint dwMessage, [In] ref APPBARDATA pData);
+    }
+}

--- a/CSDeskBand/Interop/User32.cs
+++ b/CSDeskBand/Interop/User32.cs
@@ -3,7 +3,7 @@ using System.Runtime.InteropServices;
 
 namespace CSDeskBand.Interop
 {
-    class User32
+    internal class User32
     {
         [DllImport("user32.dll", SetLastError = true)]
         public static extern int SetParent(IntPtr hWndChild, IntPtr hWndNewParent);

--- a/CSDeskBand/Interop/tagDeskBandCID.cs
+++ b/CSDeskBand/Interop/tagDeskBandCID.cs
@@ -6,7 +6,7 @@ using System.Threading.Tasks;
 
 namespace CSDeskBand.Interop
 {
-    public enum tagDESKBANDCID
+    internal enum tagDESKBANDCID
     {
         DBID_BANDINFOCHANGED = 0,
         DBID_SHOWONLY = 1,

--- a/CSDeskBand/TaskbarInfo.cs
+++ b/CSDeskBand/TaskbarInfo.cs
@@ -1,0 +1,110 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using CSDeskBand.Interop;
+using System.Runtime.InteropServices;
+
+namespace CSDeskBand
+{
+    public enum TaskbarOrientation
+    {
+        Vertical,
+        Horizontal,
+    }
+
+    public enum Edge : uint
+    {
+        Left,
+        Top,
+        Right,
+        Bottom,
+    }
+
+    public class TaskbarInfo
+    {
+        public TaskbarOrientation Orientation
+        {
+            get
+            {
+                return _orientation;
+            }
+
+            private set
+            {
+                if (value == _orientation)
+                {
+                    return;
+                }
+
+                _orientation = value;
+                TaskbarOrientationChanged?.Invoke(this, new TaskbarOrientationChangedEventArgs { Orientation = value });
+            }
+        }
+
+        public Edge Edge
+        {
+            get
+            {
+                return _edge;
+            }
+
+            private set
+            {
+                if (value == _edge)
+                {
+                    return;
+                }
+
+                _edge = value;
+                TaskbarEdgeChanged?.Invoke(this, new TaskbarEdgeChangedEventArgs { Edge = value });
+            }
+        }
+
+        public Size Size
+        {
+            get
+            {
+                return _size;
+            }
+
+            private set
+            {
+                if (value.Equals(_size))
+                {
+                    return;
+                }
+
+                _size = value;
+                TaskbarSizeChanged?.Invoke(this, new TaskbarSizeChangedEventArgs { Size = value });
+            }
+        }
+
+        public EventHandler<TaskbarOrientationChangedEventArgs> TaskbarOrientationChanged;
+        public EventHandler<TaskbarEdgeChangedEventArgs> TaskbarEdgeChanged;
+        public EventHandler<TaskbarSizeChangedEventArgs> TaskbarSizeChanged;
+
+        private TaskbarOrientation _orientation = TaskbarOrientation.Horizontal;
+        private Edge _edge = Edge.Bottom;
+        private Size _size;
+
+        internal TaskbarInfo()
+        {
+            UpdateInfo();
+        }
+
+        internal void UpdateInfo()
+        {
+            APPBARDATA data = new APPBARDATA();
+            data.hWnd = IntPtr.Zero;
+            data.cbSize = Marshal.SizeOf(typeof(APPBARDATA));
+            var res = Shell32.SHAppBarMessage((uint)APPBARMESSAGE.ABM_GETTASKBARPOS, ref data);
+
+            var rect = data.rc;
+            Size = new Size(rect.right - rect.left, rect.bottom - rect.top);
+            Edge = (Edge)data.uEdge;
+            Orientation = (Edge == Edge.Bottom || Edge == Edge.Top) ? TaskbarOrientation.Horizontal : TaskbarOrientation.Vertical;
+        }
+    }
+}


### PR DESCRIPTION
- Add taskbar info to provide info and events when taskbar changes.
- Change visibility of some classes

Taskbarinfo will provide information about taskabr size, edge, orientation and events for when it changes