### PR TITLE
Remove 'ComVisible' on assembly level

### DIFF
--- a/CSDeskBand.Win/Properties/AssemblyInfo.cs
+++ b/CSDeskBand.Win/Properties/AssemblyInfo.cs
@@ -17,7 +17,7 @@ using System.Runtime.InteropServices;
 // Setting ComVisible to false makes the types in this assembly not visible
 // to COM components.  If you need to access a type in this assembly from
 // COM, set the ComVisible attribute to true on that type.
-[assembly: ComVisible(true)]
+[assembly: ComVisible(false)]
 
 // The following GUID is for the ID of the typelib if this project is exposed to COM
 [assembly: Guid("0b37aa31-ca9c-4b2c-b541-22284fcad5f2")]

--- a/CSDeskBand.Wpf/Properties/AssemblyInfo.cs
+++ b/CSDeskBand.Wpf/Properties/AssemblyInfo.cs
@@ -19,7 +19,7 @@ using System.Windows;
 // Setting ComVisible to false makes the types in this assembly not visible
 // to COM components.  If you need to access a type in this assembly from
 // COM, set the ComVisible attribute to true on that type.
-[assembly: ComVisible(true)]
+[assembly: ComVisible(false)]
 
 //In order to begin building localizable applications, set
 //<UICulture>CultureYouAreCodingWith</UICulture> in your .csproj file

--- a/CSDeskBand/Properties/AssemblyInfo.cs
+++ b/CSDeskBand/Properties/AssemblyInfo.cs
@@ -17,7 +17,7 @@ using System.Runtime.InteropServices;
 // Setting ComVisible to false makes the types in this assembly not visible
 // to COM components.  If you need to access a type in this assembly from
 // COM, set the ComVisible attribute to true on that type.
-[assembly: ComVisible(true)]
+[assembly: ComVisible(false)]
 
 // The following GUID is for the ID of the typelib if this project is exposed to COM
 [assembly: Guid("37ecdfdd-fa85-4b91-b69f-8b53cb2a23e2")]

--- a/Sample.Win/Properties/AssemblyInfo.cs
+++ b/Sample.Win/Properties/AssemblyInfo.cs
@@ -17,7 +17,7 @@ using System.Runtime.InteropServices;
 // Setting ComVisible to false makes the types in this assembly not visible
 // to COM components.  If you need to access a type in this assembly from
 // COM, set the ComVisible attribute to true on that type.
-[assembly: ComVisible(true)]
+[assembly: ComVisible(false)]
 
 // The following GUID is for the ID of the typelib if this project is exposed to COM
 [assembly: Guid("4ee0b5c1-e49b-4ce8-ad43-75db00104a00")]

--- a/Sample.Wpf/Properties/AssemblyInfo.cs
+++ b/Sample.Wpf/Properties/AssemblyInfo.cs
@@ -19,7 +19,7 @@ using System.Windows;
 // Setting ComVisible to false makes the types in this assembly not visible
 // to COM components.  If you need to access a type in this assembly from
 // COM, set the ComVisible attribute to true on that type.
-[assembly: ComVisible(true)]
+[assembly: ComVisible(false)]
 
 //In order to begin building localizable applications, set
 //<UICulture>CultureYouAreCodingWith</UICulture> in your .csproj file


### PR DESCRIPTION
Changed it so that deskband classes will have to explicitly use ComVisible attribute