### PR TITLE
Some updates for wpf sample and other changes

### DIFF
--- a/CSDeskBand.Win/CSDeskBandWin.cs
+++ b/CSDeskBand.Win/CSDeskBandWin.cs
@@ -7,8 +7,8 @@ using CSDeskBand.Logging;
 namespace CSDeskBand.Win
 {
     /// <summary>
-    /// Winforms deskband. Your deskband should inherit this class.
-    /// Your deskband should also have these attributes <see cref="ComVisibleAttribute"/>, <see cref="GuidAttribute"/>, <see cref="CSDeskBandRegistrationAttribute"/>.
+    /// Winforms deskband. The deskband should inherit this class.
+    /// The deskband should also have these attributes <see cref="ComVisibleAttribute"/>, <see cref="GuidAttribute"/>, <see cref="CSDeskBandRegistrationAttribute"/>.
     /// Look at Sample.Win for an example
     /// </summary>
     public class CSDeskBandWin: UserControl, ICSDeskBand
@@ -28,11 +28,25 @@ namespace CSDeskBand.Win
                 _impl.VisibilityChanged += VisibilityChanged;
                 _impl.Closed += OnClose;
                 TaskbarInfo = _impl.TaskbarInfo;
+
+                SizeChanged += CSDeskBandWin_SizeChanged;
             }
             catch (Exception e)
             {
                 _logger.DebugException("Initialization Error", e);
                 throw;
+            }
+        }
+
+        private void CSDeskBandWin_SizeChanged(object sender, EventArgs e)
+        {
+            if (TaskbarInfo.Orientation == TaskbarOrientation.Horizontal)
+            {
+                Options.Horizontal = Size;
+            }
+            else
+            {
+                Options.Vertical = Size;
             }
         }
 

--- a/CSDeskBand.Wpf/CSDeskBandWpf.cs
+++ b/CSDeskBand.Wpf/CSDeskBandWpf.cs
@@ -33,11 +33,25 @@ namespace CSDeskBand.Wpf
                 _impl = new CSDeskBandImpl(Host.Handle, Options);
                 _impl.VisibilityChanged += VisibilityChanged;
                 TaskbarInfo = _impl.TaskbarInfo;
+
+                SizeChanged += CSDeskBandWpf_SizeChanged;
             }
             catch (Exception e)
             {
                 _logger.DebugException("Initialization error", e);
                 throw;
+            }
+        }
+
+        private void CSDeskBandWpf_SizeChanged(object sender, SizeChangedEventArgs e)
+        {
+            if (TaskbarInfo.Orientation == TaskbarOrientation.Horizontal)
+            {
+                Options.Horizontal = new System.Windows.Size(ActualWidth, ActualHeight);
+            }
+            else
+            {
+                Options.Vertical = new System.Windows.Size(ActualWidth, ActualHeight);
             }
         }
 

--- a/CSDeskBand.Wpf/CSDeskBandWpf.cs
+++ b/CSDeskBand.Wpf/CSDeskBandWpf.cs
@@ -10,8 +10,8 @@ namespace CSDeskBand.Wpf
 {
     public class CSDeskBandWpf : UserControl, ICSDeskBand
     {
-        protected CSDeskBandOptions Options { get; } = new CSDeskBandOptions();
-        protected TaskbarInfo TaskbarInfo { get; }
+        public CSDeskBandOptions Options { get; } = new CSDeskBandOptions();
+        public TaskbarInfo TaskbarInfo { get; }
 
         //so we can get a handle
         protected ElementHost Host { get; }

--- a/CSDeskBand/CSDeskBandOptions.cs
+++ b/CSDeskBand/CSDeskBandOptions.cs
@@ -27,12 +27,12 @@ namespace CSDeskBand
         /// </summary>
         public static readonly int NoLimit = -1;
 
-        private Size _horizontal = new Size(200, TaskbarHorizontalHeightLarge);
-        private Size _maxHorizontal = new Size(NoLimit, 200);
-        private Size _minHorizontal = new Size(200, TaskbarHorizontalHeightSmall);
-        private Size _vertical = new Size(TaskbarVerticalWidth, 200);
-        private Size _maxVertical = new Size(TaskbarVerticalWidth, NoLimit);
-        private Size _minVertical = new Size(TaskbarVerticalWidth, 200);
+        private Size _horizontal;
+        private Size _maxHorizontal;
+        private Size _minHorizontal;
+        private Size _vertical;
+        private Size _maxVertical;
+        private Size _minVertical;
         private bool _newRow = false;
         private bool _addToFront = false;
         private bool _topRow = false;
@@ -227,6 +227,7 @@ namespace CSDeskBand
             {
                 if (value.Equals(_minVertical)) return;
                 _minVertical = value;
+                _minVertical.PropertyChanged += (sender, args) => OnPropertyChanged();
                 OnPropertyChanged();
             }
         }
@@ -241,6 +242,7 @@ namespace CSDeskBand
             {
                 if (value.Equals(_maxVertical)) return;
                 _maxVertical = value;
+                _maxVertical.PropertyChanged += (sender, args) => OnPropertyChanged();
                 OnPropertyChanged();
             }
         }
@@ -255,6 +257,7 @@ namespace CSDeskBand
             {
                 if (value.Equals(_vertical)) return;
                 _vertical = value;
+                _vertical.PropertyChanged += (sender, args) => OnPropertyChanged();
                 OnPropertyChanged();
             }
         }
@@ -269,6 +272,7 @@ namespace CSDeskBand
             {
                 if (value.Equals(_minHorizontal)) return;
                 _minHorizontal = value;
+                _minHorizontal.PropertyChanged += (sender, args) => OnPropertyChanged();
                 OnPropertyChanged();
             }
         }
@@ -283,6 +287,7 @@ namespace CSDeskBand
             {
                 if (value.Equals(_maxHorizontal)) return;
                 _maxHorizontal = value;
+                _maxHorizontal.PropertyChanged += (sender, args) => OnPropertyChanged();
                 OnPropertyChanged();
             }
         }
@@ -297,8 +302,21 @@ namespace CSDeskBand
             {
                 if (value.Equals(_horizontal)) return;
                 _horizontal = value;
+                _horizontal.PropertyChanged += (sender, args) => OnPropertyChanged();
                 OnPropertyChanged();
             }
+        }
+
+        public CSDeskBandOptions()
+        {
+            //initialize in constructor to hook up property change events
+            Horizontal = new Size(200, TaskbarHorizontalHeightLarge);
+            MaxHorizontal = new Size(NoLimit, NoLimit);
+            MinHorizontal = new Size(NoLimit, NoLimit);
+
+            Vertical = new Size(TaskbarVerticalWidth, 200);
+            MaxVertical = new Size(NoLimit, NoLimit);
+            MinVertical = new Size(NoLimit, NoLimit);
         }
 
         public event PropertyChangedEventHandler PropertyChanged;

--- a/CSDeskBand/Size.cs
+++ b/CSDeskBand/Size.cs
@@ -1,11 +1,36 @@
 ﻿using System;
+using System.ComponentModel;
+using System.Runtime.CompilerServices;
+using CSDeskBand.Annotations;
 
 namespace CSDeskBand
 {
-    public class Size
+    public class Size : INotifyPropertyChanged
     {
-        public int Width { get; set; }
-        public int Height { get; set; }
+        private int _width;
+        private int _height;
+
+        public int Width
+        {
+            get => _width;
+            set
+            {
+                if (value == _width) return;
+                _width = value;
+                OnPropertyChanged();
+            }
+        }
+
+        public int Height
+        {
+            get => _height;
+            set
+            {
+                if (value == _height) return;
+                _height = value;
+                OnPropertyChanged();
+            }
+        }
 
         public Size(int width, int height)
         {
@@ -31,6 +56,14 @@ namespace CSDeskBand
         public static implicit operator System.Drawing.Size(Size size)
         {
             return new System.Drawing.Size(size.Width, size.Height);
+        }
+
+        public event PropertyChangedEventHandler PropertyChanged;
+
+        [NotifyPropertyChangedInvocator]
+        protected virtual void OnPropertyChanged([CallerMemberName] string propertyName = null)
+        {
+            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
         }
     }
 }

--- a/Sample.Wpf/UserControl1.xaml
+++ b/Sample.Wpf/UserControl1.xaml
@@ -1,4 +1,4 @@
-﻿<deskband:CSDeskBandWpf Height="40" x:Class="Sample.Wpf.UserControl1"
+﻿<deskband:CSDeskBandWpf x:Class="Sample.Wpf.UserControl1"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
@@ -6,9 +6,34 @@
              xmlns:local="clr-namespace:Sample.Wpf"
              xmlns:deskband="clr-namespace:CSDeskBand.Wpf;assembly=CSDeskBand.Wpf"
              mc:Ignorable="d" 
-             d:DesignHeight="300" d:DesignWidth="300">
-    <Grid VerticalAlignment="Top">
-        <Button Content="Button" HorizontalAlignment="Left" Margin="109,10,0,0" VerticalAlignment="Top" Width="75"/>
-
-    </Grid>
+             d:DesignHeight="300" d:DesignWidth="300"
+             HorizontalAlignment="Stretch" VerticalAlignment="Stretch"
+             DataContext="{Binding RelativeSource={RelativeSource Self}}"
+             Foreground="White">
+    <WrapPanel HorizontalAlignment="Stretch" VerticalAlignment="Stretch" Orientation="{Binding TaskbarOrientation}">
+        <GroupBox Header="Deskband" BorderThickness="1" VerticalAlignment="Stretch" HorizontalAlignment="Stretch">
+            <StackPanel Orientation="{Binding TaskbarOrientation}" HorizontalAlignment="Stretch" VerticalAlignment="Stretch">
+                <StackPanel.Resources>
+                    <Style TargetType="Label">
+                        <Setter Property="Foreground" Value="White" />
+                    </Style>
+                </StackPanel.Resources>
+                <Label ContentStringFormat="Width: {0}" Content="{Binding ActualWidth}"/>
+                <Label ContentStringFormat="Height: {0}" Content="{Binding ActualHeight}"/>
+            </StackPanel>
+        </GroupBox>
+        <GroupBox Header="Taskbar" BorderThickness="1" VerticalAlignment="Stretch" HorizontalAlignment="Stretch">
+            <StackPanel Orientation="{Binding TaskbarOrientation}" HorizontalAlignment="Stretch" VerticalAlignment="Stretch">
+                <StackPanel.Resources>
+                    <Style TargetType="Label">
+                        <Setter Property="Foreground" Value="White" />
+                    </Style>
+                </StackPanel.Resources>
+                <Label ContentStringFormat="Width: {0}" Content="{Binding TaskbarWidth}"/>
+                <Label ContentStringFormat="Height: {0}" Content="{Binding TaskbarHeight}"/>
+                <Label ContentStringFormat="Edge: {0:F}" Content="{Binding TaskbarEdge}"/>
+                <Label ContentStringFormat="Orientation: {0:F}" Content="{Binding TaskbarOrientation}"/>
+            </StackPanel>
+        </GroupBox>
+    </WrapPanel>
 </deskband:CSDeskBandWpf>

--- a/Sample.Wpf/UserControl1.xaml.cs
+++ b/Sample.Wpf/UserControl1.xaml.cs
@@ -1,6 +1,9 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.ComponentModel;
+using System.Globalization;
 using System.Linq;
+using System.Runtime.CompilerServices;
 using System.Text;
 using System.Threading.Tasks;
 using System.Windows;
@@ -15,17 +18,91 @@ using System.Windows.Shapes;
 using CSDeskBand.Wpf;
 using System.Runtime.InteropServices;
 using CSDeskBand;
+using CSDeskBand.Annotations;
 
 namespace Sample.Wpf
 {
     [ComVisible(true)]
     [Guid("89BF6B36-A0B0-4C95-A666-87A55C226986")]
     [CSDeskBandRegistration(Name = "Sample WPF Deskband")]
-    public partial class UserControl1
+    public partial class UserControl1 : INotifyPropertyChanged
     {
+        private Orientation _taskbarOrientation;
+        private int _taskbarWidth;
+        private int _taskbarHeight;
+        private Edge _taskbarEdge;
+
+        public Orientation TaskbarOrientation
+        {
+            get => _taskbarOrientation;
+            set
+            {
+                if (value == _taskbarOrientation) return;
+                _taskbarOrientation = value;
+                OnPropertyChanged();
+            }
+        }
+
+        public int TaskbarWidth
+        {
+            get => _taskbarWidth;
+            set
+            {
+                if (value == _taskbarWidth) return;
+                _taskbarWidth = value;
+                OnPropertyChanged();
+            }
+        }
+
+        public int TaskbarHeight
+        {
+            get => _taskbarHeight;
+            set
+            {
+                if (value == _taskbarHeight) return;
+                _taskbarHeight = value;
+                OnPropertyChanged();
+            }
+        }
+
+        public Edge TaskbarEdge
+        {
+            get => _taskbarEdge;
+            set
+            {
+                if (value == _taskbarEdge) return;
+                _taskbarEdge = value;
+                OnPropertyChanged();
+            }
+        }
+
         public UserControl1()
         {
             InitializeComponent();
+            Options.MinHorizontal.Width = 500;
+            Options.MinVertical.Width = 130;
+            Options.MinVertical.Height = 200;
+
+            TaskbarInfo.TaskbarEdgeChanged += (sender, args) => TaskbarEdge = args.Edge;
+            TaskbarInfo.TaskbarOrientationChanged += (sender, args) => TaskbarOrientation = args.Orientation == CSDeskBand.TaskbarOrientation.Horizontal ? Orientation.Horizontal : Orientation.Vertical;
+            TaskbarInfo.TaskbarSizeChanged += (sender, args) =>
+            {
+                TaskbarWidth = args.Size.Width;
+                TaskbarHeight = args.Size.Height;
+            };
+
+            TaskbarEdge = TaskbarInfo.Edge;
+            TaskbarOrientation = TaskbarInfo.Orientation == CSDeskBand.TaskbarOrientation.Horizontal ? Orientation.Horizontal : Orientation.Vertical;
+            TaskbarWidth = TaskbarInfo.Size.Width;
+            TaskbarHeight = TaskbarInfo.Size.Height;
+        }
+
+        public event PropertyChangedEventHandler PropertyChanged;
+
+        [NotifyPropertyChangedInvocator]
+        protected virtual void OnPropertyChanged([CallerMemberName] string propertyName = null)
+        {
+            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
         }
     }
 }


### PR DESCRIPTION
Change default options for min and max size of the deskband to be no limit.
Wpf sample is updated so that it shows information about the taskbar and deskband